### PR TITLE
Feature/add chat font size setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "vue-observe-visibility": "^1.0.0",
     "vue-router": "^3.6.5",
     "vuex": "^3.6.2",
-    "youtubei.js": "^12.2.0"
+    "youtubei.js": "^13.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -109,7 +109,6 @@
       >
         <!-- <keep-alive> -->
         <RouterView
-          ref="router"
           class="routerView"
         />
         <!-- </keep-alive> -->

--- a/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.vue
+++ b/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="sponsorBlockCategory">
     <div
-      :id="sanitizedId"
+      :id="id"
       class="sponsorTitle"
     >
       {{ translatedCategoryName }}
     </div>
     <FtSelect
-      :sanitized-id="sanitizedId + 'categoryColor'"
-      :describe-by-id="sanitizedId"
+      :sanitized-id="id + 'categoryColor'"
+      :describe-by-id="id"
       :placeholder="$t('Settings.SponsorBlock Settings.Category Color')"
       :value="sponsorBlockValues.color"
       :select-names="colorNames"
@@ -19,8 +19,8 @@
       @change="updateColor"
     />
     <FtSelect
-      :sanitized-id="sanitizedId + 'skipOption'"
-      :describe-by-id="sanitizedId"
+      :sanitized-id="id + 'skipOption'"
+      :describe-by-id="id"
       :placeholder="$t('Settings.SponsorBlock Settings.Skip Options.Skip Option')"
       :value="sponsorBlockValues.skip"
       :select-names="skipNames"
@@ -33,6 +33,7 @@
 
 <script setup>
 import { computed } from 'vue'
+import { useId } from '../../composables/use-id-polyfill'
 import { useI18n } from '../../composables/use-i18n-polyfill'
 
 import FtSelect from '../ft-select/ft-select.vue'
@@ -40,7 +41,6 @@ import FtSelect from '../ft-select/ft-select.vue'
 import store from '../../store/index'
 
 import { colors } from '../../helpers/colors'
-import { sanitizeForHtmlId } from '../../helpers/accessibility'
 import { useColorTranslations } from '../../composables/colors'
 
 const props = defineProps({
@@ -69,8 +69,7 @@ const skipNames = computed(() => [
 const COLOR_VALUES = colors.map(color => color.name)
 const colorNames = useColorTranslations()
 
-// TODO: Replace with `useId()` in Vue 3
-const sanitizedId = sanitizeForHtmlId(props.categoryName)
+const id = useId()
 
 /** @type {import('vue').ComputedRef<{ color: string, skip: string }>} */
 const sponsorBlockValues = computed(() => {

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -1,6 +1,5 @@
 <template>
   <FtFlexBox
-    ref="sideNav"
     class="sideNav"
     :class="[{closed: !isOpen}, applyHiddenLabels]"
     role="navigation"

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -39,8 +39,8 @@
         />
       </div>
     </div>
-    <template v-if="usingElectron">
-      <FtFlexBox>
+    <FtFlexBox>
+      <template v-if="usingElectron">
         <FtSlider
           :label="$t('Settings.Theme Settings.UI Scale')"
           :default-value="uiScale"
@@ -50,9 +50,17 @@
           value-extension="%"
           @change="updateUiScale"
         />
-      </FtFlexBox>
-      <br>
-    </template>
+      </template>
+      <FtSlider
+        :label="$t('Settings.Theme Settings.Chat Font Size')"
+        :default-value="chatFontSize"
+        :min-value="6"
+        :max-value="96"
+        :step="1"
+        value-extension="px"
+        @change="updateChatFontSize"
+      />
+    </FtFlexBox>
     <FtFlexBox>
       <FtSelect
         :placeholder="$t('Settings.Theme Settings.Base Theme.Base Theme')"
@@ -263,6 +271,16 @@ const uiScale = computed(() => store.getters.getUiScale)
  */
 function updateUiScale(value) {
   store.dispatch('updateUiScale', value)
+}
+
+/** @type {import('vue').ComputedRef<number>} */
+const chatFontSize = computed(() => store.getters.getChatFontSize)
+
+/**
+ * @param {number} value
+ */
+function updateChatFontSize(value) {
+  store.dispatch('updateChatFontSize', value)
 }
 
 /** @type {boolean} */

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -800,10 +800,6 @@ export default defineComponent({
       this.addToPlaylistPromptCloseCallback = () => {
         // Run once only
         this.addToPlaylistPromptCloseCallback = null
-
-        // `thumbnailLink` is a `router-link`
-        // `focus()` can only be called on the actual element
-        this.$refs.addToPlaylistIcon?.$el?.focus()
       }
     },
 

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -47,7 +47,6 @@
       <span class="playlistIcons">
         <ft-icon-button
           v-if="showPlaylists"
-          ref="addToPlaylistIcon"
           :title="$t('User Playlists.Add to Playlist')"
           :icon="['fas', 'plus']"
           class="addToPlaylistIcon"

--- a/src/renderer/components/ft-select/ft-select.vue
+++ b/src/renderer/components/ft-select/ft-select.vue
@@ -3,7 +3,7 @@
     <select
       :id="sanitizedId ?? sanitizedPlaceholder"
       ref="select"
-      :describe-by-id="describeById"
+      :aria-describedby="describeById"
       class="select-text"
       :class="{disabled: disabled}"
       :value="value"

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -84,7 +84,6 @@
       <div
         v-if="!hideSearchBar"
         v-show="showSearchContainer"
-        ref="searchContainer"
         class="searchContainer"
       >
         <ft-input

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
@@ -185,7 +185,6 @@
 
 .chatContent {
   margin-block: 5px 2px;
-  font-size: 12px;
   word-wrap: break-word;
 }
 

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
@@ -121,6 +121,7 @@
   background-color: var(--primary-color);
   border-radius: 5px;
   position: relative;
+  max-inline-size: 90%;
 }
 
 .upperSuperChatMessage {
@@ -181,6 +182,7 @@
 .liveChatComments {
   inline-size: 100%;
   overflow-y: auto;
+  font-size: var(--chat-font-size);
 }
 
 .chatContent {

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
@@ -125,11 +125,10 @@
 }
 
 .upperSuperChatMessage {
-  margin-block-start: -15px;
-  inline-size: 100%;
+  inline-size: 55px;
   block-size: 55px;
   background-color: var(--primary-color-hover);
-  border-radius: 5px 5px 0 0;
+  border-radius: 5px 0;
 }
 
 .openedSuperChat .superChatMessage {
@@ -142,6 +141,7 @@
 
 .comment .upperSuperChatMessage {
   padding: 0;
+  margin-block-start: -5px;
 }
 
 .comment {
@@ -154,8 +154,8 @@
 
 .upperSuperChatMessage .channelThumbnail {
   inline-size: 45px;
-  margin-inline-start: 10px;
-  margin-block-start: 5px;
+  margin-inline: 5px;
+  margin-block: 5px;
 }
 
 .upperSuperChatMessage .channelName {

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
@@ -86,7 +86,10 @@ export default defineComponent({
 
     formattedWatchingCount: function () {
       return this.watchingCount !== null ? formatNumber(this.watchingCount) : '0'
-    }
+    },
+    chatFontSize: function () {
+      return this.$store.getters.getChatFontSize + 'px'
+    },
   },
   beforeDestroy: function () {
     this.hasEnded = true

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
@@ -90,6 +90,9 @@ export default defineComponent({
     chatFontSize: function () {
       return this.$store.getters.getChatFontSize + 'px'
     },
+    donationTopMargin: function () {
+      return 'calc(4px - ' + this.$store.getters.getChatFontSize + 'px' + ')'
+    },
   },
   beforeDestroy: function () {
     this.hasEnded = true

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.vue
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.vue
@@ -154,6 +154,7 @@
               </p>
               <p
                 class="donationAmount"
+                :style="{ top: donationTopMargin }"
               >
                 {{ comment.superChat.amount }}
               </p>

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.vue
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.vue
@@ -126,7 +126,7 @@
       <div
         ref="liveChatComments"
         class="liveChatComments"
-        :style="{ blockSize: chatHeight }"
+        :style="{ blockSize: chatHeight, fontSize: chatFontSize }"
         @mousewheel="e => onScroll(e)"
         @scrollend="e => onScroll(e, true)"
       >

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -691,8 +691,8 @@ export function parseLocalChannelHeader(channel, onlyIdNameThumbnail = false) {
 
         subscriberText = header.content.metadata.metadata_rows
           .flatMap(row => row.metadata_parts ? row.metadata_parts : [])
-          .find(part => part.text.text?.includes('subscriber'))
-          ?.text.text
+          .find(part => part.text?.text?.includes('subscriber'))
+          ?.text?.text
       }
 
       break

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -299,6 +299,7 @@ const state = {
   // If the playlist is removed quick bookmark is disabled
   quickBookmarkTargetPlaylistId: 'favorites',
   generalAutoLoadMorePaginatedItemsEnabled: false,
+  chatFontSize: 12,
 
   // The settings below have side effects
   currentLocale: 'system',
@@ -398,6 +399,10 @@ const sideEffectHandlers = {
       const { webFrame } = require('electron')
       webFrame.setZoomFactor(value / 100)
     }
+  },
+
+  chatFontSize: (_, value) => {
+    sessionStorage.setItem('chatFontSize', value)
   }
 }
 

--- a/static/locales/cs.yaml
+++ b/static/locales/cs.yaml
@@ -187,6 +187,8 @@ User Playlists:
       This playlist has a video with a duration error: Tento playlist obsahuje nejméně
         jedno video, které nemá dobu trvání. Bude seřazeno tak, jako by mělo dobu
         trvání nula.
+      Video has been removed. Click here to undo.: Video bylo odstraněno. Klikněte
+        sem pro zrušení akce.
     Search for Videos: Hledat videa
   Are you sure you want to delete this playlist? This cannot be undone: Opravdu chcete
     odstranit tento playlist? Tato akce je nevratná.
@@ -406,7 +408,7 @@ Settings:
   Player Settings:
     Player Settings: 'Přehrávač'
     Play Next Video: 'Automaticky přehrávat doporučená videa'
-    Turn on Subtitles by Default: 'Ve výchozím nastavení zapnout titulky'
+    Turn on Subtitles by Default: 'Ve výchozím nastavení povolit titulky'
     Autoplay Videos: 'Automaticky spouštět videa'
     Proxy Videos Through Invidious: 'Proxy videa prostřednictvím Invidious'
     Autoplay Playlists: 'Automaticky přehrávat videa v playlistu'
@@ -456,6 +458,12 @@ Settings:
     Enter Fullscreen on Display Rotate: Při otočení displeje přejít na celou obrazovku
     Skip by Scrolling Over Video Player: Posouvat čas posuvem kolečka myši na přehrávači
     Autoplay Interruption Timer: Čas přerušení automatického přehrávání
+    Default Viewing Mode:
+      Theater: Kino
+      Default Viewing Mode: Výchozí režim sledování
+      Full Screen: Celá obrazovka
+      External Player: Externí přehrávač ({externalPlayerName})
+      Picture in Picture: Obraz v obraze
   Privacy Settings:
     Privacy Settings: 'Soukromí'
     Remember History: 'Zapamatovat historii sledování'

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1181,7 +1181,7 @@ External link opening has been disabled in the general settings: Das Öffnen ext
 Downloading has completed: „{videoTitle}“ wurde vollständig heruntergeladen
 Starting download: Herunterladen von „{videoTitle}“ wird gestartet
 Downloading failed: Beim Herunterladen von „{videoTitle}“ gab es ein Problem
-Screenshot Success: Bildschirmfoto gespeichert
+Screenshot Success: Gespeichertes Bildschirmfoto
 Screenshot Error: Bildschirmfoto fehlgeschlagen. {error}
 New Window: Neues Fenster
 Channels:

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -412,7 +412,7 @@ Settings:
   Player Settings:
     Player Settings: Videoabspieler
     Play Next Video: Empfohlene Videos automatisch abspielen
-    Turn on Subtitles by Default: Untertitel standardmäßig aktivieren
+    Turn on Subtitles by Default: Untertitel standardmäßig einschalten
     Autoplay Videos: Videos automatisch starten
     Proxy Videos Through Invidious: Proxy-Videos durch Invidious
     Autoplay Playlists: Wiedergabelisten-Videos automatisch abspielen
@@ -461,6 +461,12 @@ Settings:
     Enter Fullscreen on Display Rotate: Beim Drehen des Bildschirms zu Vollbild wechseln
     Skip by Scrolling Over Video Player: Überspringen durch Scrollen über den Videoabspieler
     Autoplay Interruption Timer: Automatische Wiedergabe Unterbrechungs-Timer
+    Default Viewing Mode:
+      Theater: Theater
+      Picture in Picture: Bild im Bild
+      External Player: Externer Player ({externalPlayerName})
+      Full Screen: Vollbild
+      Default Viewing Mode: Standard-Ansichtsmodus
   Subscription Settings:
     Subscription Settings: Abo
     Hide Videos on Watch: Videos bei Wiedergabe ausblenden

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -322,6 +322,7 @@ Settings:
     Expand Side Bar by Default: Expand Side Bar by Default
     Disable Smooth Scrolling: Disable Smooth Scrolling
     UI Scale: UI Scale
+    Chat Font Size: Chat Font Size
     Hide Side Bar Labels: Hide Side Bar Labels
     Hide FreeTube Header Logo: Hide FreeTube Header Logo
     Base Theme:

--- a/static/locales/et.yaml
+++ b/static/locales/et.yaml
@@ -201,6 +201,8 @@ User Playlists:
       This playlist has a video with a duration error: Selles esitusloendis on vähemalt
         üks video, millel puudub kestus. Järjestamisel me sel puhul arvestame kestuseks
         nulli.
+      Video has been removed. Click here to undo.: Video on eemaldatud. Tagasipööramiseks
+        klõpsi siin.
     Search for Videos: Otsi videoid
   Are you sure you want to delete this playlist? This cannot be undone: Kas sa oled
     kindel, et soovid selle esitusloendi kustutada? Seda tegevust ei saa tagasi pöörata.
@@ -450,6 +452,12 @@ Settings:
     Skip by Scrolling Over Video Player: Jäta vahele, kerides üle videopleieri
     Enter Fullscreen on Display Rotate: Ekraani pööramisel ava täisekraanivaade
     Autoplay Interruption Timer: Viivituse taimer järgmise video esitamise katkestamisel
+    Default Viewing Mode:
+      Full Screen: Täisekraanivaade
+      External Player: Väline meediamängija ({externalPlayerName})
+      Theater: Teatrivaade
+      Default Viewing Mode: Vaikimisi vaade
+      Picture in Picture: Pilt pildis vaade
   Privacy Settings:
     Privacy Settings: 'Privaatsus'
     Remember History: 'Jäta vaatamiste ajalugu meelde'

--- a/static/locales/eu.yaml
+++ b/static/locales/eu.yaml
@@ -461,6 +461,12 @@ Settings:
     Skip by Scrolling Over Video Player: Saltatu bideo-erreproduzitzailean korrituz
     Enter Fullscreen on Display Rotate: Sartu pantaila osoko pantaila biratu pantailan
     Autoplay Interruption Timer: Erreprodukzio automatikoa eteteko tenporizadorea
+    Default Viewing Mode:
+      Default Viewing Mode: Ikusteko modu lehenetsia
+      Full Screen: Pantaila osoa
+      Picture in Picture: Irudia Irudian
+      External Player: Kanpo erreproduzitzailea ({externalPlayerName})
+      Theater: Antzerkia
   Privacy Settings:
     Privacy Settings: 'Pribatutasuna'
     Remember History: 'Ikusitakoaren historikoa oroitu'
@@ -1295,3 +1301,4 @@ KeyboardShortcutPrompt:
   Close Window: Itxi leihoa
   Show Keyboard Shortcuts: Erakutsi teklatuko laster-bideak
   History Backward: Egin orrialde bat atzera
+shortcutLabelSeparator: ｜

--- a/static/locales/fa.yaml
+++ b/static/locales/fa.yaml
@@ -182,6 +182,8 @@ User Playlists:
       This playlist has a video with a duration error: این لیست پخش شامل حداقل یک
         ویدیو است که مدت زمان ندارد، به گونه‌ای مرتب می‌شود که گویی مدت زمان آنها
         صفر است.
+      Video has been removed. Click here to undo.: ویدیو حذف شد. برای لغو اینجا کلیک
+        کنید.
     Search for Videos: جستجوی ویدئوها
   Sort By:
     EarliestUpdatedFirst: اولین به روز شده
@@ -306,6 +308,7 @@ Settings:
       Gruvbox Dark: جعبه تیره تاریک
       Gruvbox Light: جعبه تیره روشن
       Nordic: شمال اروپا
+      Catppuccin Frappe: تم رنگ کت پوچین فراپه
     Main Color Theme:
       Main Color Theme: 'رنگ تم اصلی'
       Red: 'قرمز'
@@ -369,11 +372,11 @@ Settings:
     Hide FreeTube Header Logo: لوگوی سربرگ FreeTube را مخفی کنید
   Player Settings:
     Player Settings: 'پخش کننده'
-    Play Next Video: 'پخش ویدیو بعدی'
+    Play Next Video: 'پخش اتوماتیک ویدیو پیشنهادی'
     Turn on Subtitles by Default: 'فعال کردن زیرنویس به عنوان پیشفرض'
     Autoplay Videos: 'پخش خودکار ویدیو ها'
     Proxy Videos Through Invidious: 'پروکسی ویدیو ها از طریق Invidious'
-    Autoplay Playlists: 'پخش خودکار فهرست های پخش'
+    Autoplay Playlists: 'پخش خودکار فهرست  پخش'
     Enable Theatre Mode by Default: 'فعال کردن حالت تئاتر به عنوان پیشفرض'
     Scroll Volume Over Video Player: 'کنترل صدا با حرکت اسکرول موس روی پخش کننده ویدیو'
     Display Play Button In Video Player: 'نمایش دکمه پخش داخل پخش کننده ویدیو'
@@ -420,6 +423,11 @@ Settings:
       Folder Button: پوشه را انتخاب کنید
     Skip by Scrolling Over Video Player: با پیمایش روی پخش‌کننده ویدیو از آن بگذرید
     Autoplay Interruption Timer: تایمر وقفه پخش خودکار
+    Default Viewing Mode:
+      Theater: تئاتر
+      Default Viewing Mode: حالت تماشای پیش‌فرض
+      Full Screen: تمام صفحه
+      Picture in Picture: تصویر در تصویر
   External Player Settings:
     External Player Settings: 'پخش کننده خارجی'
     External Player: 'پخش کننده خارجی'
@@ -893,6 +901,7 @@ Tooltips:
       و یک کش تصویر سفارشی در حافظه را فعال می کند. منجر به افزایش مصرف رم خواهد شد.
 Search Bar:
   Clear Input: پاک کردن ورودی
+  Remove: حذف
 Are you sure you want to open this link?: آیا مطمئن هستید که میخواهید این لینک را
   باز کنید؟
 About:

--- a/static/locales/hr.yaml
+++ b/static/locales/hr.yaml
@@ -187,6 +187,8 @@ User Playlists:
       This playlist has a video with a duration error: Ova zbirka sadrži barem jedan
         video koji nema trajanje. Video će se svrstati kao da je njegovo trajanje
         nula.
+      Video has been removed. Click here to undo.: Video je uklonjen. Klikni ovdje
+        za poništavanje uklanjanja.
     Search for Videos: Traži videa
   AddVideoPrompt:
     N playlists selected: 'Odabrano: {playlistCount}'
@@ -391,11 +393,11 @@ Settings:
     Hide FreeTube Header Logo: Sakrij FreeTube logotip u zaglavlju
   Player Settings:
     Player Settings: 'Player'
-    Play Next Video: 'Reproduciraj sljedeći video'
+    Play Next Video: 'Automatski reproduciraj preporučena videa'
     Turn on Subtitles by Default: 'Standardno uključi titlove'
-    Autoplay Videos: 'Automatski reproduciraj videa'
+    Autoplay Videos: 'Pokreni videa automatski'
     Proxy Videos Through Invidious: 'Koristi Invidious kao posrednika videa'
-    Autoplay Playlists: 'Automatski reproduciraj zbirke'
+    Autoplay Playlists: 'Automatski reproduciraj videa zbirki'
     Enable Theatre Mode by Default: 'Standardno aktiviraj kazališni modus'
     Default Volume: 'Standardna glasnoća'
     Default Playback Rate: 'Standardna brzina reprodukcije'
@@ -907,6 +909,8 @@ Video:
     Audio Tracks: Audio snimke
     Exit Theatre Mode: Zatvori kazališni modus
     Full Window: Cjeloekranski prikaz
+    Autoplay is off: Automatska reprodukcija je isključena
+    Autoplay is on: Automatska reprodukcija je uključena
   MembersOnly: Videa koja su namijenjena samo za članove ne mogu se gledati putem
     FreeTubea jer zahtijevaju prijavu na Google i plaćeno članstvo na kanalu prenositelja.
   Unlisted: Skriveni za javnost

--- a/static/locales/hu.yaml
+++ b/static/locales/hu.yaml
@@ -468,7 +468,7 @@ Settings:
       Theater: Színház
       Picture in Picture: Kép a képben
       External Player: Külső lejátszó ({externalPlayerName})
-      Default Viewing Mode: Alapértelmezett megjelenítési mód
+      Default Viewing Mode: Alapértelmezett nézetmód
   Privacy Settings:
     Privacy Settings: 'Adatvédelem'
     Remember History: 'Megtekintési előzmények megjegyzése'

--- a/static/locales/hu.yaml
+++ b/static/locales/hu.yaml
@@ -191,6 +191,8 @@ User Playlists:
       This playlist has a video with a duration error: Ez a lejátszási lista legalább
         egy olyan videót tartalmaz, amelynek nincs időtartama, ezért úgy lesz rendezve,
         mintha az időtartamuk nulla lenne.
+      Video has been removed. Click here to undo.: A videó etávolításra került. Kattintson
+        ide a visszavonáshoz.
     Search for Videos: Videók keresése
   Are you sure you want to delete this playlist? This cannot be undone: Biztosan törölni
     szeretné ezt a lejátszási listát? Ezt nem lehet visszacsinálni.
@@ -409,7 +411,7 @@ Settings:
   Player Settings:
     Player Settings: 'Lejátszó'
     Play Next Video: 'Ajánlott videók automatikus lejátszása'
-    Turn on Subtitles by Default: 'Feliratok bekapcsolása alapértelemezetten'
+    Turn on Subtitles by Default: 'Feliratok engedélyezése alapértelemezetten'
     Autoplay Videos: 'Videók automatikus elindítása'
     Proxy Videos Through Invidious: 'Videók proxyzása az Invidiouson keresztül'
     Autoplay Playlists: 'Lejátszási lista az automatikus videó-lejátszáshoz'
@@ -461,6 +463,12 @@ Settings:
     Enter Fullscreen on Display Rotate: Teljes képernyős mód a kijelzőn forgatáshoz
     Skip by Scrolling Over Video Player: Kihagyás a Videolejátszó felett görgetve
     Autoplay Interruption Timer: Automatikus lejátszás megszakításának időköze
+    Default Viewing Mode:
+      Full Screen: Teljes képernyő
+      Theater: Színház
+      Picture in Picture: Kép a képben
+      External Player: Külső lejátszó ({externalPlayerName})
+      Default Viewing Mode: Alapértelmezett megjelenítési mód
   Privacy Settings:
     Privacy Settings: 'Adatvédelem'
     Remember History: 'Megtekintési előzmények megjegyzése'

--- a/static/locales/it.yaml
+++ b/static/locales/it.yaml
@@ -184,6 +184,8 @@ User Playlists:
       This playlist has a video with a duration error: Questa playlist contiene almeno
         un video che non ha durata; verranno ordinati come se la loro durata fosse
         zero.
+      Video has been removed. Click here to undo.: Il video è stato rimosso. Clicca
+        qui per annullare.
     Search for Videos: Ricerca nei video
   Are you sure you want to delete this playlist? This cannot be undone: Sei sicuro
     di voler eliminare questa playlist? Questa operazione non può essere annullata.
@@ -451,6 +453,12 @@ Settings:
     Enter Fullscreen on Display Rotate: Entra a schermo intero su Ruota schermo
     Skip by Scrolling Over Video Player: Salta tramite scorrimento sul lettore video
     Autoplay Interruption Timer: Timer di interruzione della riproduzione automatica
+    Default Viewing Mode:
+      Full Screen: Schermo intero
+      Picture in Picture: Immagine nell'immagine
+      External Player: Lettore esterno ({externalPlayerName})
+      Default Viewing Mode: Modalità di visualizzazione predefinita
+      Theater: Teatro
   Privacy Settings:
     Privacy Settings: 'Privacy'
     Remember History: 'Ricorda la Cronologia delle visualizzazioni'

--- a/static/locales/sr.yaml
+++ b/static/locales/sr.yaml
@@ -189,6 +189,8 @@ User Playlists:
       This playlist has a video with a duration error: Ова плејлиста садржи најмање
         један видео снимак који нема трајање, биће сортиран као да је његово трајање
         нула.
+      Video has been removed. Click here to undo.: Видео снимак је уклоњен. Додирните
+        овде да поништите.
     Search for Videos: Претрага видео снимака
   Are you sure you want to delete this playlist? This cannot be undone: Желите ли
     заиста да избришете ову плејлисту? Ово се не може поништити.
@@ -408,7 +410,7 @@ Settings:
   Player Settings:
     Player Settings: 'Плејер'
     Play Next Video: 'Аутоматски пусти препоручене видео снимке'
-    Turn on Subtitles by Default: 'Подразумевано укључи титлове'
+    Turn on Subtitles by Default: 'Подразумевано омогући титлове'
     Autoplay Videos: 'Аутоматски пусти видео снимке'
     Proxy Videos Through Invidious: 'Прокси видео снимци преко Invidious-а'
     Autoplay Playlists: 'Аутоматски пусти видео снимке с плејлисте'
@@ -460,6 +462,12 @@ Settings:
     Display Play Button In Video Player: Прикажи дугме за пуштање у плејеру видео
       снимка
     Autoplay Interruption Timer: Тајмер за прекид аутоплеја
+    Default Viewing Mode:
+      Theater: Биоскоп
+      Default Viewing Mode: Подразумевани режим гледања
+      Full Screen: Цео екран
+      External Player: Спољни плејер ({externalPlayerName})
+      Picture in Picture: Слика у слици
   Privacy Settings:
     Privacy Settings: 'Приватност'
     Remember History: 'Запамти историју гледања'
@@ -1265,3 +1273,4 @@ KeyboardShortcutPrompt:
   Volume Down: Смањивање јачине звука
   Small Fast Forward: Брзо премотавање унапред X секунди засновано на интервалу брзог
     премотавања унапред и тренутној брзини репродукције видео снимка
+shortcutLabelSeparator: ｜

--- a/static/locales/uk.yaml
+++ b/static/locales/uk.yaml
@@ -195,6 +195,8 @@ User Playlists:
       There was an issue with updating this playlist.: Сталася помилка при оновленні
         цієї добірки.
       There were no videos to remove.: Відео для видалення не знайдено.
+      Video has been removed. Click here to undo.: Відео видалено. Натисніть тут,
+        щоб скасувати.
     Search for Videos: Пошук відео
   The playlist has been successfully exported: Добірку успішно експортовано
   Export Playlist: Експортувати цю добірку
@@ -407,7 +409,7 @@ Settings:
   Player Settings:
     Player Settings: 'Плеєр'
     Play Next Video: 'Автовідтворення рекомендованих відео'
-    Turn on Subtitles by Default: 'Увімкнути субтитри за замовченням'
+    Turn on Subtitles by Default: 'Увімкнути субтитри за замовчуванням'
     Autoplay Videos: 'Автоматично запускати відео'
     Proxy Videos Through Invidious: 'Проксі-відео через Invidious'
     Autoplay Playlists: 'Автовідтворення відео з добірки'
@@ -458,6 +460,12 @@ Settings:
       екрана
     Skip by Scrolling Over Video Player: Пропустити гортанням відеопрогравача
     Autoplay Interruption Timer: Таймер переривання автозапуску
+    Default Viewing Mode:
+      Picture in Picture: Картинка в картинці
+      Theater: Театр
+      External Player: Зовнішній плеєр ({externalPlayerName})
+      Default Viewing Mode: Режим перегляду за замовчуванням
+      Full Screen: Повноекранний режим
   Privacy Settings:
     Privacy Settings: 'Конфіденційність'
     Remember History: 'Зберігати історію переглядів'
@@ -1270,3 +1278,4 @@ KeyboardShortcutPrompt:
   Last Chapter: Останній розділ
   Skip by Tenths: Пропустити відео на певний відсоток (3 пропуски до 30% тривалості)
   Next Chapter: Наступний розділ
+shortcutLabelSeparator: ｜

--- a/static/locales/zh-CN.yaml
+++ b/static/locales/zh-CN.yaml
@@ -161,6 +161,7 @@ User Playlists:
       This playlist is already being used for quick bookmark.: 此播放列表已被用于快速书签。
       This playlist has a video with a duration error: 此播放列表包含至少一个没有持续时间的视频，排序时将按照持续时间为
         0 对待此视频。
+      Video has been removed. Click here to undo.: 视频已被删除。单击此处撤销。
     Search for Videos: 搜索视频
   Are you sure you want to delete this playlist? This cannot be undone: 你确定要删除此播放列表吗？此操作无法撤销。
   Sort By:
@@ -408,6 +409,12 @@ Settings:
     Enter Fullscreen on Display Rotate: 屏幕旋转时进入全屏
     Skip by Scrolling Over Video Player: 从视频播放器一侧滚动到另一侧来跳过视频
     Autoplay Interruption Timer: 自动播放中断计时器
+    Default Viewing Mode:
+      Default Viewing Mode: 默认观看模式
+      Picture in Picture: 画中画
+      External Player: 外部播放器({externalPlayerName})
+      Theater: 影院
+      Full Screen: 全屏
   Subscription Settings:
     Subscription Settings: '订阅'
     Hide Videos on Watch: '观看时隐藏视频'
@@ -1109,3 +1116,4 @@ KeyboardShortcutPrompt:
   Minimize Window: 最小化窗口
   Zoom Out: 放大
   Next Chapter: 下一章节
+shortcutLabelSeparator: ｜

--- a/yarn.lock
+++ b/yarn.lock
@@ -9736,10 +9736,10 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
-youtubei.js@^12.2.0:
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-12.2.0.tgz#54f058b5d0892b5c7e35019e2be6a2a7f7ba4447"
-  integrity sha512-G+50qrbJCToMYhu8jbaHiS3Vf+RRul+CcDbz3hEGwHkGPh+zLiWwD6SS+YhYF+2/op4ZU5zDYQJrGqJ+wKh7Gw==
+youtubei.js@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-13.0.0.tgz#f036bc6f5cb9ef8bd73da7e1079a2b70776bb2f7"
+  integrity sha512-b1QkN9bfgphK+5tI4qteSK54kNxmPhoedvMw0jl4uSn+L8gbDbJ4z52amNuYNcOdp4X/SI3JuUb+f5V0DPJ8Vw==
   dependencies:
     "@bufbuild/protobuf" "^2.0.0"
     jintr "^3.2.0"


### PR DESCRIPTION
# Add a setting to change chat font size

## Pull Request Type
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #6613 

## Description
This PR adds a setting to change the font size used in a livestream chat.

I also took the liberty of changing some things relating to superchats:
- I moved the donation amount to the top of the block so it does not overlap with the message
- I put a max width of 90% to the superchat block so there is no horizontal bar
- I moved the profile picture inside the block (I think it being a bit outside, like a tab, does not fit in the chat, but I'm open to suggestions)
These are minor modifications in the code, I didn't want to create multiple PRs for such simple changes. If they should be separated, I'd be glad to create other PRs.

## Screenshots
Before the change
![image](https://github.com/user-attachments/assets/43d2330b-b2a6-47b6-8c39-fb3437756400)

After the change (example uses a 32px font size)
![image](https://github.com/user-attachments/assets/32aa31ba-1f60-44e6-a774-98c354cc99d0)

The new setting is in the Theme section
![image](https://github.com/user-attachments/assets/b2c8d73d-3229-4a2f-9344-7087d0f42722)

## Testing
1. Open a livestream
2. Check the size of the text in the chat box changes
3. Pray there is also a superchat

## Desktop
- **OS:** Manjaro Linux
- **OS Version:** 24.2.1